### PR TITLE
Add AWS credentials to SECRET_ADMIN_KEYS

### DIFF
--- a/fredagscafeen/settings/base.py
+++ b/fredagscafeen/settings/base.py
@@ -110,6 +110,13 @@ SECRET_ADMIN_KEYS = [
         "role": "WEB",
     },
     {
+        "key": "AWS_PASSWORD",
+        "description": "AWS. OBS: Kontoen har 2FA",
+        "username": "web@fredagscafeen.dk",
+        "url": "https://aws.amazon.com/console/",
+        "role": "WEB",
+    },
+    {
         "key": "MIDTTRAFIK_BESTILLING_PASSWORD",
         "description": "midttrafikbestilling.dk",
         "username": "fredagscafeen",


### PR DESCRIPTION
This pull request adds a new entry for AWS credentials to the list of stored account information. The new entry includes a description, username, URL, and notes that the account uses 2FA.

Credential management update:

* Added an entry for `AWS_PASSWORD` with relevant details to the credentials list in `fredagscafeen/settings/base.py`.