### PR TITLE
Add Dansk Retursystem credentials to SECRET_ADMIN_KEYS

### DIFF
--- a/fredagscafeen/settings/base.py
+++ b/fredagscafeen/settings/base.py
@@ -122,6 +122,13 @@ SECRET_ADMIN_KEYS = [
         "role": "WEB",
     },
     {
+        "key": "DANSK_RETUR_SYSTEM_PASSWORD",
+        "description": "Dansk Retursystem",
+        "username": "5790001782870",
+        "url": "https://danskretursystem.dk/booking/",
+        "role": "DRIFT",
+    },
+    {
         "key": "MIDTTRAFIK_BESTILLING_PASSWORD",
         "description": "midttrafikbestilling.dk",
         "username": "fredagscafeen",

--- a/fredagscafeen/settings/base.py
+++ b/fredagscafeen/settings/base.py
@@ -122,7 +122,7 @@ SECRET_ADMIN_KEYS = [
         "role": "WEB",
     },
     {
-        "key": "DANSK_RETUR_SYSTEM_PASSWORD",
+        "key": "DANSK_RETURSYSTEM_PASSWORD",
         "description": "Dansk Retursystem",
         "username": "5790001782870",
         "url": "https://danskretursystem.dk/booking/",


### PR DESCRIPTION
This pull request adds a new entry for Dansk Retursystem credentials to the settings configuration. This enables the application to manage and reference the Dansk Retursystem login details in a structured way.

Credentials management:

* Added a `DANSK_RETURSYSTEM_PASSWORD` entry to the `fredagscafeen/settings/base.py` credentials list, including description, username, URL, and role information.