### PR TITLE
fix: remove reference to board in reminder email content

### DIFF
--- a/reminder/management/commands/send_barshift_reminder.py
+++ b/reminder/management/commands/send_barshift_reminder.py
@@ -38,7 +38,7 @@ Husk at der på fredag er {common_event.title}!
         return f"""Hej {humanized_bartenders}.
 
 Den kommende fredag er det JERES tur til at stå i Fredagscaféen.
-Dette er en automatisk email sendt til jer og bestyrelsen.
+Dette er en automatisk email sendt til jer.
 Emailen er hovedsageligt sendt så I kan finde en anden at bytte vagt med,
 hvis en af jer ikke har mulighed for selv at tage den.
 Husk at jeres vagt starter kl. {start_time}.


### PR DESCRIPTION
This pull request makes a minor update to the content of the reminder email sent to bartenders. The message now clarifies that the email is sent only to the bartenders, not to both them and the board.

- Updated the email body in `send_barshift_reminder.py` to state that the reminder is sent only to bartenders, removing the mention of the board.