### PR TITLE
feat: add latex_escape filter for special character handling in LaTeX

### DIFF
--- a/items/templates/barmenu/barmenu.tex
+++ b/items/templates/barmenu/barmenu.tex
@@ -1,4 +1,5 @@
 {% load latex_trunc %}
+{% load latex_escape %}
 
 \documentclass[a4paper,oneside,article,11pt,landscape]{memoir}
 \usepackage[margin=1cm]{geometry}
@@ -40,6 +41,7 @@
 
 \begin{minipage}[l]{0.45\linewidth}
 \begin{longtable}[l]{p{2.2cm}p{6cm}rp{1.5cm} }
+
 \large {{ shelf.name }} & & &  \\
 \toprule
 \textbf{Type} & \textbf{Name} & \textbf{Price} &  \\
@@ -56,9 +58,9 @@
 
 {% for shelf_item in shelf.shelf_items.all %}
 {% with item=shelf_item.item %}
-{{ item.type.name|default:"--" }} &
-{{ item.latex_safe_name }} &
-{{ item.priceInDKK|floatformat:0 }} kr &
+{{ item.type.name|default:"--"|latex_escape }} &
+{{ item.latex_safe_name|latex_escape }} &
+{{ item.priceInDKK|floatformat:0|latex_escape }} kr &
 {% if item.glutenFree %}\glutenfree{% endif %}{% if item.nonAlcoholic %}{% if item.glutenFree %}, {% endif %}\nonalcoholic{% endif %} \\
 {% endwith %}
 {% endfor %}

--- a/items/templatetags/latex_escape.py
+++ b/items/templatetags/latex_escape.py
@@ -1,0 +1,25 @@
+from django import template
+from django.template.defaultfilters import stringfilter
+
+register = template.Library()
+
+
+@register.filter(name="latex_escape")
+@stringfilter
+def latex_escape(value):
+    """
+    Escapes special characters in a string for use in LaTeX documents.
+    """
+    chars = {
+        "&": r"\&",
+        "%": r"\%",
+        "$": r"\$",
+        "#": r"\#",
+        "_": r"\_",
+        "{": r"\{",
+        "}": r"\}",
+        "~": r"\textasciitilde{}",
+        "^": r"\textasciicircum{}",
+        "\\": r"\textbackslash{}",
+    }
+    return "".join(chars.get(c, c) for c in value)


### PR DESCRIPTION
This pull request introduces LaTeX escaping for menu item fields in the bar menu template to prevent issues with special characters when rendering LaTeX documents. The main change is the addition and use of a custom Django template filter to safely escape LaTeX-sensitive characters in rendered text.

**LaTeX escaping improvements:**

* Added a new template filter `latex_escape` in `items/templatetags/latex_escape.py` to escape special LaTeX characters in strings.
* Updated the `barmenu.tex` template to load the new `latex_escape` filter and apply it to the item type name, item name, and price fields, ensuring safe LaTeX output. [[1]](diffhunk://#diff-fdedb10facbb8c5f62ea9739b61e6d6d99d5ec561536976433fc3687743028f3R2) [[2]](diffhunk://#diff-fdedb10facbb8c5f62ea9739b61e6d6d99d5ec561536976433fc3687743028f3L59-R63)

**Template adjustments:**

* Minor formatting adjustment in `barmenu.tex` for improved code clarity.