### PR TITLE
feat: add command to send reminders for Aarhus Bryghus access renewal

### DIFF
--- a/reminder/management/commands/send_bryghus_access_reminder.py
+++ b/reminder/management/commands/send_bryghus_access_reminder.py
@@ -1,0 +1,41 @@
+from constance import config
+from django.conf import settings
+from django.core.management.base import BaseCommand
+
+from fredagscafeen.email import send_template_email
+from mail.models import MailingList
+
+
+class Command(BaseCommand):
+    help = "Sends a reminder to the beer mailing list with a notification about refreshing the Aarhus Bryghus external card access"
+
+    def handle(self, *args, **options):
+        if not config.SEND_REMINDERS:
+            print("SEND_REMINDERS is false, not sending any reminders.")
+            return
+
+        body_template = """
+Det er blevet tid til at forny Aarhus Bryghus' adgangskort til p-kælderen!
+
+Dette skal gøres hver 3. måned, og kortet udløber omkring d. 29. i måneden.
+
+Det fornyes ved at skrive til Tina (rudolph@cs.au.dk) eller Mette (mmd@cs.au.dk). Alternativt kan cardaccess@cs.au.dk også videresende opgaven.
+
+Fra du sender mailen, skal opgaven sendes videre til en centraladminstration. Dette kan tage op til en uge, så skriv med det samme til én af de ovenstående!
+
+Aarhus Bryghus' kort har følgende oplysninger:
+EXTERNAL IDENTITY CARD
+Aarhus Bryghus Fredagscafe, øl-depot ADA
+Kortnr. 060546
+Nummer ved magnetstribe: 106820
+"""
+
+        send_template_email(
+            subject="VIGTIGT: Aarhus Bryghus adgang udløber!",
+            body_template=body_template,
+            to=[f"beer@{settings.DOMAIN}"],
+            cc=[f"reminder@{settings.DOMAIN}"],
+            reply_to=[f"best@{settings.DOMAIN}"],
+        )
+
+        print(f"Reminders sent to the beer mailing list!")

--- a/reminder/tasks.py
+++ b/reminder/tasks.py
@@ -6,6 +6,9 @@ from .management.commands.send_barshift_reminder import (
 from .management.commands.send_boardgamecart_rental_reminder import (
     Command as BoardGameCartRentalReminderCommand,
 )
+from .management.commands.send_bryghus_access_reminder import (
+    Command as BryghusAccessReminderCommand,
+)
 from .management.commands.send_grill_rental_reminder import (
     Command as GrillRentalReminderCommand,
 )
@@ -69,4 +72,10 @@ def send_tent_rental_reminder():
 @shared_task
 def send_boardgamecart_rental_reminder():
     c = BoardGameCartRentalReminderCommand()
+    c.run_from_argv(["", ""])
+
+
+@shared_task
+def send_bryghus_access_reminder():
+    c = BryghusAccessReminderCommand()
     c.run_from_argv(["", ""])


### PR DESCRIPTION
This pull request introduces a new reminder system for Aarhus Bryghus card access and integrates it with the existing reminder framework. The main changes are the addition of a new management command for sending the reminder email, and registering it as a Celery task for scheduled execution.

**New Bryghus Access Reminder Functionality:**

* Added a new management command `send_bryghus_access_reminder.py` that sends an email reminder to the beer mailing list about renewing Aarhus Bryghus' external card access, including all relevant instructions and card details.

**Integration with Task System:**

* Registered the new command in `reminder/tasks.py` so it can be imported and used as a task.
* Added a new Celery shared task `send_bryghus_access_reminder` that invokes the management command, allowing the reminder to be scheduled or triggered asynchronously.