### PR TITLE
feat: add from_email parameter to send_template_email for reminder

### DIFF
--- a/fredagscafeen/email.py
+++ b/fredagscafeen/email.py
@@ -11,6 +11,7 @@ def send_template_email(
     html_format={},
     cc=[],
     reply_to=[settings.BEST_MAIL],
+    from_email=None,
 ):
     body_text = render_to_string(
         "email.txt", {"content": body_template.format(**text_format)}
@@ -25,6 +26,7 @@ def send_template_email(
         to=to,
         cc=cc,
         reply_to=reply_to,
+        from_email=from_email,
     )
     email.attach_alternative(body_html, "text/html")
     return email.send()

--- a/reminder/management/commands/send_bryghus_access_reminder.py
+++ b/reminder/management/commands/send_bryghus_access_reminder.py
@@ -34,6 +34,7 @@ Nummer ved magnetstribe: 106820
             subject="VIGTIGT: Aarhus Bryghus adgang udløber!",
             body_template=body_template,
             to=[f"beer@{settings.DOMAIN}"],
+            from_email=f"Fredagscafeen <reminder@{settings.DOMAIN}>",
             cc=[f"reminder@{settings.DOMAIN}"],
             reply_to=[f"best@{settings.DOMAIN}"],
         )


### PR DESCRIPTION
This pull request introduces support for specifying a custom `from_email` address when sending template emails. The main changes involve updating the `send_template_email` function to accept a `from_email` parameter and passing it through to the email backend. Additionally, the Bryghus access reminder command now sets a specific `from_email` value for its outgoing emails.

**Email sending improvements:**

* Added an optional `from_email` parameter to the `send_template_email` function in `fredagscafeen/email.py`, allowing callers to specify the sender address.
* Updated the email creation in `send_template_email` to use the provided `from_email` value when sending emails.

**Reminder command update:**

* Modified the Bryghus access reminder management command to set a custom `from_email` ("Fredagscafeen <reminder@...>") when sending notifications.