### PR TITLE
Reduce shelf label dimensions for improved layout

### DIFF
--- a/items/templates/shelf_labels/shelf_labels.tex
+++ b/items/templates/shelf_labels/shelf_labels.tex
@@ -9,6 +9,8 @@
 \usepackage{multicol}
 \usepackage[export]{adjustbox}
 \usepackage{graphicx}
+\usepackage[outline]{contour}
+\contourlength{0.4pt} % Adjust this to make it thicker/thinner
 
 \pdfinclusionerrorlevel=0
 \pdfminorversion=7
@@ -65,7 +67,7 @@
                 \vspace{0.6mm}
                 {\scriptsize #6 \par}
                 \vfill
-                {\raggedleft\LARGE\bfseries #7~kr.\par}
+                {\raggedleft\huge\bfseries\contour{black}{#7}kr.\par}
             \end{minipage}
         \end{tabular}
     \end{minipage}%

--- a/items/templates/shelf_labels/shelf_labels.tex
+++ b/items/templates/shelf_labels/shelf_labels.tex
@@ -2,7 +2,7 @@
 
 \documentclass[10pt]{article}
 \usepackage[utf8]{inputenc}
-\usepackage[margin=0.5cm]{geometry}
+\usepackage[margin=0.1cm]{geometry}
 \usepackage[pdftex]{graphicx}
 \usepackage{tabularx}
 \usepackage{array}
@@ -16,14 +16,14 @@
 \setlength{\parindent}{0pt}
 
 \newcommand{\LabelHeight}{3.5cm}
-\newcommand{\LabelWidth}{10.0cm}
-\newcommand{\ImageColumnWidth}{3.3cm}
-\newcommand{\TextColumnWidth}{6.0cm}
+\newcommand{\LabelWidth}{8.0cm}
+\newcommand{\ImageColumnWidth}{2.2cm}
+\newcommand{\TextColumnWidth}{5.5cm}
 
 \newcommand{\PlaceholderImg}{%
     \includegraphics[
-        max width=2.6cm,
-        max height=2.4cm,
+        max width=2.0cm,
+        max height=2.0cm,
         keepaspectratio
     ]{/app/staticfiles/images/logo.png}%
 }
@@ -31,8 +31,8 @@
 \newcommand{\Img}[1]{%
     \includegraphics[
         trim=0 0 0 0, clip,
-        max width=2.6cm,
-        max height=2.4cm,
+        max width=2.0cm,
+        max height=2.0cm,
         keepaspectratio
     ]{\detokenize{#1}}%
 }


### PR DESCRIPTION
This pull request makes adjustments to the `shelf_labels.tex` LaTeX template to reduce the overall size of shelf labels and their image placeholders. The main changes involve shrinking the label width, image, and text columns, as well as reducing the margins.

Layout and sizing adjustments:

* Reduced page margin from 0.5cm to 0.1cm to fit more content per page (`shelf_labels.tex`).
* Decreased label width (`LabelWidth`), image column width (`ImageColumnWidth`), and text column width (`TextColumnWidth`) to create smaller labels (`shelf_labels.tex`).
* Reduced maximum width and height for both placeholder and actual images to ensure they fit the smaller label size (`shelf_labels.tex`).

## Screenshots
<img width="1038" height="531" alt="Screenshot 2026-05-05 at 22 14 57" src="https://github.com/user-attachments/assets/afc0ef43-16cd-4d99-b93a-19973372f698" />
