### PR TITLE
feat: add Pant Container configuration to admin keys

### DIFF
--- a/fredagscafeen/settings/base.py
+++ b/fredagscafeen/settings/base.py
@@ -222,6 +222,13 @@ SECRET_ADMIN_KEYS = [
         "role": "DRIFT",
     },
     {
+        "key": "PANT_CONTAINER",
+        "description": "Pant-Containere i P-kælderen.",
+        "username": "N/A",
+        "url": "N/A",
+        "role": "DRIFT",
+    },
+    {
         "key": "SALLING_GROUP_BUSINESS_PASSWORD",
         "description": "Salling Group Business",
         "username": "best@fredagscafeen.dk",

--- a/fredagscafeen/settings/base.py
+++ b/fredagscafeen/settings/base.py
@@ -224,8 +224,8 @@ SECRET_ADMIN_KEYS = [
     {
         "key": "PANT_CONTAINER",
         "description": "Pant-Containere i P-kælderen.",
-        "username": "N/A",
-        "url": "N/A",
+        "username": "",
+        "url": "",
         "role": "DRIFT",
     },
     {


### PR DESCRIPTION
This pull request adds a new entry for "Pant-Containere i P-kælderen" to the configuration in `fredagscafeen/settings/base.py`. This entry includes a key, description, and role, with placeholders for username and URL.

Configuration updates:

* Added a new configuration item with key `PANT_CONTAINER`, describing the pant containers in the parking basement, under the "DRIFT" role.