### PR TITLE
feat: Add new LEDVANCE_PASSWORD

### DIFF
--- a/fredagscafeen/settings/base.py
+++ b/fredagscafeen/settings/base.py
@@ -222,6 +222,13 @@ SECRET_ADMIN_KEYS = [
         "role": "DRIFT",
     },
     {
+        "key": "LEDVANCE_PASSWORD",
+        "description": "Ledvance SMART+ Mobile App",
+        "username": "best@fredagscafeen.dk",
+        "url": "https://www.ledvance.com/da-dk/belysning-til-hjemmet/serviceydelser/styringsmulighed/smart-app",
+        "role": "DRIFT",
+    },
+    {
         "key": "SALLING_GROUP_BUSINESS_PASSWORD",
         "description": "Salling Group Business",
         "username": "best@fredagscafeen.dk",


### PR DESCRIPTION
This pull request adds a new entry to the credentials configuration in the `fredagscafeen/settings/base.py` file. The new entry stores credentials for the Ledvance SMART+ Mobile App.

Credentials configuration update:

* Added a new dictionary entry for `LEDVANCE_PASSWORD`, including its description, username, URL, and role, to the credentials list in `base.py`.