### PR TITLE
feat: add CTIPARTY_PASSWORD credentials to admin keys

### DIFF
--- a/fredagscafeen/settings/base.py
+++ b/fredagscafeen/settings/base.py
@@ -236,6 +236,13 @@ SECRET_ADMIN_KEYS = [
         "role": "DRIFT",
     },
     {
+        "key": "CTIPARTY_PASSWORD",
+        "description": "Ctiparty",
+        "username": "best@fredagscafeen.dk",
+        "url": "https://www.ctiparty.dk/",
+        "role": "DRIFT",
+    },
+    {
         "key": "SALLING_GROUP_BUSINESS_PASSWORD",
         "description": "Salling Group Business",
         "username": "best@fredagscafeen.dk",


### PR DESCRIPTION
This pull request makes a small change to the `fredagscafeen/settings/base.py` file by adding a new entry for CTIPARTY credentials. The new entry includes the key, description, username, URL, and role for CTIPARTY.

* Added CTIPARTY credentials to the list of service accounts, specifying the key, description, username, URL, and role.