### PR TITLE
fix: enable timezone awareness for Celery beat scheduling

### DIFF
--- a/fredagscafeen/settings/base.py
+++ b/fredagscafeen/settings/base.py
@@ -397,10 +397,11 @@ DATABASES = {
 LANGUAGE_CODE = "da"
 
 TIME_ZONE = "Europe/Copenhagen"
+CELERY_TIMEZONE = "Europe/Copenhagen"
 
 USE_I18N = True
 
-DJANGO_CELERY_BEAT_TZ_AWARE = False
+DJANGO_CELERY_BEAT_TZ_AWARE = True
 
 from django.utils.translation import gettext_lazy as _
 


### PR DESCRIPTION
This pull request makes a few small configuration changes to the timezone settings for Celery and Django Celery Beat in the `fredagscafeen/settings/base.py` file. These changes ensure that both Celery and Django Celery Beat use timezone-aware scheduling consistent with the application's configured timezone.

- Set `CELERY_TIMEZONE` to `"Europe/Copenhagen"` to align Celery's timezone with the application's timezone.
- Set `DJANGO_CELERY_BEAT_TZ_AWARE` to `True` to enable timezone-aware scheduling in Django Celery Beat.