### PR TITLE
Bugfix: Update date field to start_datetime and new common event model

### DIFF
--- a/bartenders/templates/barplan.html
+++ b/bartenders/templates/barplan.html
@@ -63,7 +63,7 @@
 						{{ shift.display_str }}{% if show_all_bartendershifts %}, {{ shift.start_datetime.year }}{% endif %}
 						{% endif %}
 						{% if shiftEvent %}
-							<span class="badge {% if shiftComparedToCurrentWeek == -1 %}text-bg-warning{% else %}text-bg-info{% endif %}">{% if shiftEvent.url %}<a href="{{ shiftEvent.url }}" target="_blank" class="common">{% bs_icon shiftEvent.url_bs_icon size='1.0em' %}{{ shiftEvent.title }}</a>{% else %}{{ shiftEvent.title }}{% endif %}</span>
+							<span class="badge {% if shiftComparedToCurrentWeek == -1 %}text-bg-warning{% else %}text-bg-info{% endif %}"><a href="{% url 'event' event_id=shiftEvent.id %}" target="_blank" class="common">{{ shiftEvent.name }}</a></span>
 						{% endif %}
 					</td>
 					{% with released_bartender_shift=shift.responsible|released_shift:shift %}

--- a/reminder/management/commands/send_barshift_reminder.py
+++ b/reminder/management/commands/send_barshift_reminder.py
@@ -27,7 +27,8 @@ class Command(ReminderCommand):
         start = event.start_datetime - datetime.timedelta(minutes=30)
         start_time = date_format(start, "H:i")
         common_event = Event.objects.filter(
-            date=event.start_datetime.date(), event_type=Event.EventType.COMMON
+            start_datetime__date=event.start_datetime.date(),
+            event_type=Event.EventType.COMMON,
         ).first()
         event_info = ""
         if common_event:
@@ -38,7 +39,7 @@ Husk at der på fredag er {common_event.name}!
         return f"""Hej {humanized_bartenders}.
 
 Den kommende fredag er det JERES tur til at stå i Fredagscaféen.
-Dette er en automatisk email sendt til jer.
+Dette er en automatisk email.
 Emailen er hovedsageligt sendt så I kan finde en anden at bytte vagt med,
 hvis en af jer ikke har mulighed for selv at tage den.
 Husk at jeres vagt starter kl. {start_time}.

--- a/web/templatetags/event_info.py
+++ b/web/templatetags/event_info.py
@@ -10,6 +10,7 @@ def event_info(shift):
     if not shift or not getattr(shift, "start_datetime", None):
         return None
 
-    shift_date = shift.start_datetime.date()
-
-    return Event.objects.filter(start_datetime__date=shift_date).first()
+    return Event.objects.filter(
+        start_datetime__date=shift.start_datetime.date(),
+        event_type=Event.EventType.COMMON,
+    ).first()


### PR DESCRIPTION
I did not receive a bar shift reminder today, so checked why, and found that the new common event model was not updated properly, so it failed. On top of that, common events were not showing on the bar plan, because of the new model. 