### PR TITLE
fix: update autocomplete fields and add horizontal filters for bartender lists

### DIFF
--- a/events/admin.py
+++ b/events/admin.py
@@ -203,7 +203,8 @@ class EventAdmin(CustomModelAdmin):
         EventResponseReadonlyInline,
     ]
     list_display_links = ("name",)
-    autocomplete_fields = ["event_album", "bartender_whitelist", "bartender_blacklist"]
+    autocomplete_fields = ["event_album"]
+    filter_horizontal = ("bartender_whitelist", "bartender_blacklist")
     search_fields = (
         "name",
         "year",


### PR DESCRIPTION
Make it easier to add multiple users to whitelist and blacklist in event. Useful when adding old board members to whitelist for events they are invited to.

Before:
<img width="1160" height="93" alt="before" src="https://github.com/user-attachments/assets/60a05b8f-98e3-4223-bdf9-64fea63ef973" />
After:
<img width="1160" height="377" alt="after" src="https://github.com/user-attachments/assets/713a77d0-9313-46a5-8a6c-a0914d9cbf11" />
